### PR TITLE
Enforce move validation

### DIFF
--- a/Term Project/Assets/Scripts/ChessPieces/Bishop.cs
+++ b/Term Project/Assets/Scripts/ChessPieces/Bishop.cs
@@ -13,7 +13,7 @@ public class Bishop : ChessPiece
     // Update is called once per frame
     void Update()
     {
-    
+        
     }
 
     public override List<Vector2Int> findValidMoves()

--- a/Term Project/Assets/Scripts/ChessPieces/ChessPiece.cs
+++ b/Term Project/Assets/Scripts/ChessPieces/ChessPiece.cs
@@ -31,6 +31,11 @@ public abstract class ChessPiece : MonoBehaviour
     private Vector3 desiredPosition;
     private Vector3 desiredScale = Vector3.one;
 
+    public List<Vector2Int> validMoves;
+    private bool hasBeenMoved;
+    
+    public ChessBoard board;
+
     private void update()
     {
         transform.position = Vector3.Lerp(transform.position, desiredPosition, Time.deltaTime * 10);
@@ -54,13 +59,6 @@ public abstract class ChessPiece : MonoBehaviour
             transform.localScale = desiredScale;
         }
     }
-    public List<Vector2Int> validMoves;
-    private bool hasBeenMoved;
-    
-    public ChessBoard board;
-
-    //private Vector3 desiredPosition;
-    //private Vector3 desiredScale;
 
     private void Awake()
     {
@@ -84,20 +82,20 @@ public abstract class ChessPiece : MonoBehaviour
 
     public void move(Vector2Int location)
     {
-        Vector2Int old_loc = new Vector2Int(currentX, currentY);
+        //Vector2Int old_loc = new Vector2Int(currentX, currentY);
 
-        currentX = location.x;
-        currentY = location.y;
+        //currentX = location.x;
+        //currentY = location.y;
 
-        board.UpdateBoardAfterMove(this, location, old_loc);
-
+        //board.UpdateBoardAfterMove(this, location, old_loc);
+        //findValidMoves();
         set_hasBeenMoved(true);
     }
 
     public bool enemyPiece(Vector2Int loc)
     {
         ChessPiece piece = this.board.getPieceOnBoard(new Vector2Int(loc.x, loc.y));
-        if(piece)
+        if(piece != null)
         {
             if(piece.team != this.team)
             {
@@ -110,7 +108,7 @@ public abstract class ChessPiece : MonoBehaviour
     public bool inTheWay(Vector2Int loc)
     {
         ChessPiece piece = this.board.getPieceOnBoard(new Vector2Int(loc.x, loc.y));
-        if(piece)
+        if(piece != null)
         {
             if(piece.team == this.team)
             {

--- a/Term Project/Assets/Scripts/ChessPieces/King.cs
+++ b/Term Project/Assets/Scripts/ChessPieces/King.cs
@@ -13,7 +13,7 @@ public class King : ChessPiece
     // Update is called once per frame
     void Update()
     {
-
+        
     }
     
     public override List<Vector2Int> findValidMoves()

--- a/Term Project/Assets/Scripts/ChessPieces/Knight.cs
+++ b/Term Project/Assets/Scripts/ChessPieces/Knight.cs
@@ -13,7 +13,7 @@ public class Knight : ChessPiece
     // Update is called once per frame
     void Update()
     {
-
+        
     }
 
     public override List<Vector2Int> findValidMoves()

--- a/Term Project/Assets/Scripts/ChessPieces/Pawn.cs
+++ b/Term Project/Assets/Scripts/ChessPieces/Pawn.cs
@@ -13,7 +13,7 @@ public class Pawn : ChessPiece
     // Update is called once per frame
     void Update()
     {
-
+        
     }
 
     private void blackMoves()

--- a/Term Project/Assets/Scripts/ChessPieces/Queen.cs
+++ b/Term Project/Assets/Scripts/ChessPieces/Queen.cs
@@ -13,7 +13,7 @@ public class Queen : ChessPiece
     // Update is called once per frame
     void Update()
     {
-
+        
     }
 
     public override List<Vector2Int> findValidMoves()

--- a/Term Project/Assets/Scripts/ChessPieces/Rook.cs
+++ b/Term Project/Assets/Scripts/ChessPieces/Rook.cs
@@ -13,7 +13,7 @@ public class Rook : ChessPiece
     // Update is called once per frame
     void Update()
     {
-
+        
     }
 
     public override List<Vector2Int> findValidMoves()


### PR DESCRIPTION
Sets all pieces' validMoves List on piece creation, and after every move. Will not allow a player to move a piece to an invalid location.